### PR TITLE
Replace 'LUA' with 'Lua'

### DIFF
--- a/EEP/EEP_LUA_Layout_01.lua
+++ b/EEP/EEP_LUA_Layout_01.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
--- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
+-- EEP Lua code to automatically drive trains from block to block.
+-- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}

--- a/EEP/EEP_LUA_Layout_01.lua
+++ b/EEP/EEP_LUA_Layout_01.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
--- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
+-- EEP Lua code to automatically drive trains from block to block.
+-- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}
@@ -190,6 +190,3 @@ function EEPMain()
   return 1
 end
 [EEPLuaData]
-DN_1 = 0.000000
-DN_2 = 0.000000
-DN_3 = 1.000000

--- a/EEP/EEP_LUA_Layout_01.lua
+++ b/EEP/EEP_LUA_Layout_01.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP Lua code to automatically drive trains from block to block.
--- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
+-- EEP LUA code to automatically drive trains from block to block.
+-- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}
@@ -190,3 +190,6 @@ function EEPMain()
   return 1
 end
 [EEPLuaData]
+DN_1 = 0.000000
+DN_2 = 0.000000
+DN_3 = 1.000000

--- a/EEP/EEP_LUA_Layout_02.lua
+++ b/EEP/EEP_LUA_Layout_02.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
--- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
+-- EEP Lua code to automatically drive trains from block to block.
+-- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}

--- a/EEP/EEP_LUA_Layout_02.lua
+++ b/EEP/EEP_LUA_Layout_02.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
--- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
+-- EEP Lua code to automatically drive trains from block to block.
+-- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}
@@ -190,8 +190,3 @@ function EEPMain()
 
   return 1
 end
-[EEPLuaData]
-DN_1 = 0.000000
-DN_2 = 0.000000
-DN_3 = 2.000000
-DN_4 = 1.000000

--- a/EEP/EEP_LUA_Layout_02.lua
+++ b/EEP/EEP_LUA_Layout_02.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP Lua code to automatically drive trains from block to block.
--- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
+-- EEP LUA code to automatically drive trains from block to block.
+-- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}
@@ -190,3 +190,8 @@ function EEPMain()
 
   return 1
 end
+[EEPLuaData]
+DN_1 = 0.000000
+DN_2 = 0.000000
+DN_3 = 2.000000
+DN_4 = 1.000000

--- a/EEP/EEP_LUA_Layout_03.lua
+++ b/EEP/EEP_LUA_Layout_03.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
--- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
+-- EEP Lua code to automatically drive trains from block to block.
+-- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}
@@ -193,11 +193,4 @@ function EEPMain()
   end
 
   return 1
-end
-[EEPLuaData]
-DN_1 = 0.000000
-DN_2 = 0.000000
-DN_3 = 0.000000
-DN_4 = 2.000000
-DN_5 = 0.000000
 DN_6 = 1.000000

--- a/EEP/EEP_LUA_Layout_03.lua
+++ b/EEP/EEP_LUA_Layout_03.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
--- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
+-- EEP Lua code to automatically drive trains from block to block.
+-- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}

--- a/EEP/EEP_LUA_Layout_03.lua
+++ b/EEP/EEP_LUA_Layout_03.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP Lua code to automatically drive trains from block to block.
--- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
+-- EEP LUA code to automatically drive trains from block to block.
+-- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}
@@ -193,4 +193,11 @@ function EEPMain()
   end
 
   return 1
+end
+[EEPLuaData]
+DN_1 = 0.000000
+DN_2 = 0.000000
+DN_3 = 0.000000
+DN_4 = 2.000000
+DN_5 = 0.000000
 DN_6 = 1.000000

--- a/EEP/EEP_LUA_Layout_04.lua
+++ b/EEP/EEP_LUA_Layout_04.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
--- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
+-- EEP Lua code to automatically drive trains from block to block.
+-- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}

--- a/EEP/EEP_LUA_Layout_04.lua
+++ b/EEP/EEP_LUA_Layout_04.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP Lua code to automatically drive trains from block to block.
--- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
+-- EEP LUA code to automatically drive trains from block to block.
+-- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}
@@ -203,6 +203,13 @@ function EEPMain()
   end
 
   return 1
+end
+[EEPLuaData]
+DN_1 = 1.000000
+DN_2 = 0.000000
+DN_3 = 0.000000
+DN_4 = 3.000000
+DN_5 = 2.000000
 DN_6 = 0.000000
 DN_7 = 0.000000
 DN_8 = 0.000000

--- a/EEP/EEP_LUA_Layout_04.lua
+++ b/EEP/EEP_LUA_Layout_04.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
--- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
+-- EEP Lua code to automatically drive trains from block to block.
+-- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}
@@ -203,13 +203,6 @@ function EEPMain()
   end
 
   return 1
-end
-[EEPLuaData]
-DN_1 = 1.000000
-DN_2 = 0.000000
-DN_3 = 0.000000
-DN_4 = 3.000000
-DN_5 = 2.000000
 DN_6 = 0.000000
 DN_7 = 0.000000
 DN_8 = 0.000000

--- a/EEP/EEP_LUA_Layout_05.lua
+++ b/EEP/EEP_LUA_Layout_05.lua
@@ -1,8 +1,8 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP Lua code to automatically drive trains from block to block.
+-- EEP LUA code to automatically drive trains from block to block.
 -- The user only has to define the layout by configuring some tables and variables
--- There's no need to write any Lua code, the code uses the data in the tables and variables.
+-- There's no need to write any LUA code, the code uses the data in the tables and variables.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@ -246,6 +246,15 @@ function EEPMain()
 
   return 1
 end
+
+[EEPLuaData]
+DN_1 = 0.000000
+DN_2 = 0.000000
+DN_3 = 0.000000
+DN_4 = 0.000000
+DN_5 = 0.000000
+DN_6 = 0.000000
+DN_7 = 5.000000
 DN_8 = 0.000000
 DN_9 = 7.000000
 DN_10 = 0.000000

--- a/EEP/EEP_LUA_Layout_05.lua
+++ b/EEP/EEP_LUA_Layout_05.lua
@@ -1,8 +1,8 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
+-- EEP Lua code to automatically drive trains from block to block.
 -- The user only has to define the layout by configuring some tables and variables
--- There's no need to write any LUA code, the code uses the data in the tables and variables.
+-- There's no need to write any Lua code, the code uses the data in the tables and variables.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/EEP/EEP_LUA_Layout_05.lua
+++ b/EEP/EEP_LUA_Layout_05.lua
@@ -1,8 +1,8 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
+-- EEP Lua code to automatically drive trains from block to block.
 -- The user only has to define the layout by configuring some tables and variables
--- There's no need to write any LUA code, the code uses the data in the tables and variables.
+-- There's no need to write any Lua code, the code uses the data in the tables and variables.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@ -246,15 +246,6 @@ function EEPMain()
 
   return 1
 end
-
-[EEPLuaData]
-DN_1 = 0.000000
-DN_2 = 0.000000
-DN_3 = 0.000000
-DN_4 = 0.000000
-DN_5 = 0.000000
-DN_6 = 0.000000
-DN_7 = 5.000000
 DN_8 = 0.000000
 DN_9 = 7.000000
 DN_10 = 0.000000

--- a/EEP/README.md
+++ b/EEP/README.md
@@ -1,3 +1,3 @@
-The EEP folder contains 5 working EEP demo layouts with the LUA code and the layout definition included.
+The EEP folder contains 5 working EEP demo layouts with the Lua code and the layout definition included.
 
 To start automatic train traffic on a layout: SHIFT + left click the main switch followed by SHIFT + left click of one or more of the individual train on/off switches.

--- a/LIESMICH.md
+++ b/LIESMICH.md
@@ -2,24 +2,24 @@ Im November 2021 bin ich in ein neues Haus gezogen. Neben den vielen Vorteilen, 
 
 Meine alte Modelleisenbahn war computergesteuert mit einem Programm namens Traincontroller. Es ermöglicht einen automatischen Zugverkehr, wobei es sich um das Schalten von Weichen und Signalen sowie das Beschleunigen und Abbremsen der Züge kümmert.
 
-Mir ist aufgefallen, dass EEP keine automatische Zugsteuerung eingebaut hat ... oder zumindest nicht in einer Weise, die benutzerfreundlich ist. Es gibt jedoch LUA, mit dem wir Code schreiben können, um diese Aufgaben auszuführen. Ich habe mich gefragt, ob es möglich wäre, ein LUA-Programm zu schreiben, das den automatischen Zugverkehr in EEP steuert, so wie es Traincontroller mit einer echten Modellbahnanlage tut.
+Mir ist aufgefallen, dass EEP keine automatische Zugsteuerung eingebaut hat ... oder zumindest nicht in einer Weise, die benutzerfreundlich ist. Es gibt jedoch Lua, mit dem wir Code schreiben können, um diese Aufgaben auszuführen. Ich habe mich gefragt, ob es möglich wäre, ein Lua-Programm zu schreiben, das den automatischen Zugverkehr in EEP steuert, so wie es Traincontroller mit einer echten Modellbahnanlage tut.
 
 Ich habe mir folgende Ziele gesetzt:
  - Die Züge sollen automatisch von Block zu Block fahren
  - Es sollte möglich sein, festzulegen, welche Züge in welchen Blöcken fahren dürfen
  - Es soll möglich sein, Haltezeiten zu definieren, pro Zug und Block
  - Es soll möglich sein, einzelne Züge zu starten / zu stoppen
- - Es soll für jede (Modell-)Bahnanlage funktionieren, ohne dass LUA-Code (neu) geschrieben werden muss
+ - Es soll für jede (Modell-)Bahnanlage funktionieren, ohne dass Lua-Code (neu) geschrieben werden muss
  - Die Anlage wird ausschließlich durch die Eingabe von Daten über Züge, Signale, Weichen und Strecken definiert
- - Das Ergebnis dieses EEP LUA Automatic Traffic Control Projekts kann hier heruntergeladen werden.
+ - Das Ergebnis dieses EEP Lua Automatic Traffic Control Projekts kann hier heruntergeladen werden.
 
-Eine Erklärung, wie es funktioniert und wie man die LUA-Tabellen mit Daten füllt, die das eigene Layout definieren, liegt bei:
+Eine Erklärung, wie es funktioniert und wie man die Lua-Tabellen mit Daten füllt, die das eigene Layout definieren, liegt bei:
  - English: EEP_LUA_Automatic+Train_Control.pdf
  - Deutsch: EEP_LUA_Automatische_Zugsteuerung.pdf
 
-Der EEP-Ordner enthält 5 funktionierende EEP-Demo-Layouts mit dem LUA-Code und der Layoutdefinition.
+Der EEP-Ordner enthält 5 funktionierende EEP-Demo-Layouts mit dem Lua-Code und der Layoutdefinition.
 
-Der LUA-Ordner enthält 5 Dateien mit dem LUA-Code, um die Bearbeitung des Codes z.B. in Notepad++ zu erleichtern.
+Der LUA-Ordner enthält 5 Dateien mit dem Lua-Code, um die Bearbeitung des Codes z.B. in Notepad++ zu erleichtern.
 
 Der TC-Ordner enthält die 5 Layouts in Traincontroller, für diejenigen, die vielleicht mit TC basteln möchten. Kostenlose Demo-Version: https://www.freiwald.com/pages/download.htm
 

--- a/LUA/EEP_LUA_Layout_01_Edit.lua
+++ b/LUA/EEP_LUA_Layout_01_Edit.lua
@@ -1,7 +1,7 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Rudy Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
--- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
+-- EEP Lua code to automatically drive trains from block to block.
+-- There's no need to write any Lua code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}
 allowed = {}

--- a/LUA/EEP_LUA_Layout_02_Edit.lua
+++ b/LUA/EEP_LUA_Layout_02_Edit.lua
@@ -1,6 +1,6 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
+-- EEP Lua code to automatically drive trains from block to block.
 -- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}

--- a/LUA/EEP_LUA_Layout_03_Edit.lua
+++ b/LUA/EEP_LUA_Layout_03_Edit.lua
@@ -1,6 +1,6 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
+-- EEP Lua code to automatically drive trains from block to block.
 -- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}

--- a/LUA/EEP_LUA_Layout_04_Edit.lua
+++ b/LUA/EEP_LUA_Layout_04_Edit.lua
@@ -1,6 +1,6 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
+-- EEP Lua code to automatically drive trains from block to block.
 -- There's no need to write any LUA code, the code uses the data in the Configuration tables and variables below.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 train   = {}

--- a/LUA/EEP_LUA_Layout_05_Edit.lua
+++ b/LUA/EEP_LUA_Layout_05_Edit.lua
@@ -1,6 +1,6 @@
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 -- Ruud Boer, January 2022
--- EEP LUA code to automatically drive trains from block to block.
+-- EEP Lua code to automatically drive trains from block to block.
 -- The user only has to define the layout by configuring some tables and variables
 -- There's no need to write any LUA code, the code uses the data in the tables and variables.
 -- @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/LUA/README.md
+++ b/LUA/README.md
@@ -1,3 +1,3 @@
-This LUA folder contains 5 files with the LUA code of the 5 demo layouts, to make it easier to edit the code in say Notepad++.
+This Lua folder contains 5 files with the Lua code of the 5 demo layouts, to make it easier to edit the code in say Notepad++.
 
 https://notepad-plus-plus.org/downloads/

--- a/README.md
+++ b/README.md
@@ -3,25 +3,25 @@ November 2021 I moved to a new house. Besides the many pluses the new home offer
 
 My old model railway was computer controlled with a program called Traincontroller. It allows for automatic train traffic whereby it takes care of switching turnouts and signals and accelerating and decelerating the trains.
 
-It struck me that EEP has no automatic train control built in … or at least not in a way that is user friendly. There is however LUA, which allows us to write code to carry out these tasks. I wondered if it would be possible to write a LUA program that controls automatic train traffic in EEP, like Traincontroller does with a real model railway layout.
+It struck me that EEP has no automatic train control built in … or at least not in a way that is user friendly. There is however Lua, which allows us to write code to carry out these tasks. I wondered if it would be possible to write a Lua program that controls automatic train traffic in EEP, like Traincontroller does with a real model railway layout.
 
 I set myself the following goals:
  - Trains should automatically drive from block to block
  - It should be possible to specify which trains are allowed in which blocks
  - It should be possible to define stop times, per train per block
  - It should be possible to start / stop individual trains
- - It should work for any (model) railway layout without the need to (re)write LUA code 
+ - It should work for any (model) railway layout without the need to (re)write Lua code 
  - The layout is defined solely by entering data on trains, signals, turnouts and routes
 
-The result of this EEP LUA Automatic Traffic Control Project can be downloaded here.
+The result of this EEP Lua Automatic Traffic Control Project can be downloaded here.
 
-An explanation on how it works and on how to fill the LUA tables with data that define your own layout goes with it:
+An explanation on how it works and on how to fill the Lua tables with data that define your own layout goes with it:
  - English: EEP_LUA_Automatic+Train_Control.pdf
  - Deutsch: EEP_LUA_Automatische_Zugsteuerung.pdf
 
-The EEP folder contains 5 working EEP demo layouts with the LUA code and the layout definition included. 
+The EEP folder contains 5 working EEP demo layouts with the Lua code and the layout definition included. 
 
-The LUA folder contains 5 files with the LUA code to make it easier to edit the code in say Notepad++.
+The LUA folder contains 5 files with the Lua code to make it easier to edit the code in say Notepad++.
 
 The TC folder contains the 5 layouts in Traincontroller, for those who might like to tinker with TC. Free demo version: https://www.freiwald.com/pages/download.htm
 


### PR DESCRIPTION
Hi Rudy,

I replaced 'LUA' with 'Lua' in all files (except for the folder name 'LUA'). 

Kind regards
Frank